### PR TITLE
chore(config): jspm auto config update

### DIFF
--- a/config.js
+++ b/config.js
@@ -9,23 +9,22 @@ System.config({
     "*": "*.js",
     "github:*": "jspm_packages/github/*.js",
     "npm:*": "jspm_packages/npm/*.js"
-  },
-  "trace": true
+  }
 });
 
 System.config({
   "map": {
-    "babel": "npm:babel-core@5.5.6",
-    "babel-runtime": "npm:babel-runtime@5.5.6",
-    "core-js": "npm:core-js@0.9.15",
+    "babel": "npm:babel-core@5.8.20",
+    "babel-runtime": "npm:babel-runtime@5.8.20",
+    "core-js": "npm:core-js@0.9.18",
     "css": "npm:jspm-loader-css-modules@0.1.2",
-    "css-global": "npm:jspm-loader-css@0.1.5",
+    "css-global": "npm:jspm-loader-css@0.1.6",
     "path": "npm:path@0.11.14",
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.3.0"
     },
     "github:jspm/nodelibs-buffer@0.1.0": {
-      "buffer": "npm:buffer@3.2.2"
+      "buffer": "npm:buffer@3.3.1"
     },
     "github:jspm/nodelibs-path@0.1.0": {
       "path-browserify": "npm:path-browserify@0.0.0"
@@ -36,7 +35,7 @@ System.config({
     "github:jspm/nodelibs-util@0.1.0": {
       "util": "npm:util@0.10.3"
     },
-    "npm:amdefine@0.1.1": {
+    "npm:amdefine@1.0.0": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "module": "github:jspm/nodelibs-module@0.1.0",
       "path": "github:jspm/nodelibs-path@0.1.0",
@@ -45,15 +44,15 @@ System.config({
     "npm:assert@1.3.0": {
       "util": "npm:util@0.10.3"
     },
-    "npm:babel-runtime@5.5.6": {
+    "npm:babel-runtime@5.8.20": {
       "process": "github:jspm/nodelibs-process@0.1.1"
     },
-    "npm:buffer@3.2.2": {
+    "npm:buffer@3.3.1": {
       "base64-js": "npm:base64-js@0.0.8",
       "ieee754": "npm:ieee754@1.1.6",
       "is-array": "npm:is-array@1.0.1"
     },
-    "npm:core-js@0.9.15": {
+    "npm:core-js@0.9.18": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "process": "github:jspm/nodelibs-process@0.1.1",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
@@ -61,7 +60,7 @@ System.config({
     "npm:css-modules-loader-core@0.0.10": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "path": "github:jspm/nodelibs-path@0.1.0",
-      "postcss": "npm:postcss@4.1.13",
+      "postcss": "npm:postcss@4.1.16",
       "postcss-modules-extract-imports": "npm:postcss-modules-extract-imports@0.0.5",
       "postcss-modules-local-by-default": "npm:postcss-modules-local-by-default@0.0.9",
       "postcss-modules-scope": "npm:postcss-modules-scope@0.0.7"
@@ -69,7 +68,8 @@ System.config({
     "npm:css-selector-tokenizer@0.4.1": {
       "fastparse": "npm:fastparse@1.1.1"
     },
-    "npm:css-selector-tokenizer@0.5.2": {
+    "npm:css-selector-tokenizer@0.5.4": {
+      "cssesc": "npm:cssesc@0.1.0",
       "fastparse": "npm:fastparse@1.1.1"
     },
     "npm:es6-promise@2.3.0": {
@@ -83,13 +83,13 @@ System.config({
     "npm:inherits@2.0.1": {
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
-    "npm:js-base64@2.1.8": {
+    "npm:js-base64@2.1.9": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0"
     },
     "npm:jspm-loader-css-modules@0.1.2": {
-      "jspm-loader-css": "npm:jspm-loader-css@0.1.5"
+      "jspm-loader-css": "npm:jspm-loader-css@0.1.6"
     },
-    "npm:jspm-loader-css@0.1.5": {
+    "npm:jspm-loader-css@0.1.6": {
       "css-modules-loader-core": "npm:css-modules-loader-core@0.0.10",
       "path": "npm:path@0.11.14"
     },
@@ -102,31 +102,29 @@ System.config({
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
     "npm:postcss-modules-extract-imports@0.0.5": {
-      "postcss": "npm:postcss@4.1.13",
+      "postcss": "npm:postcss@4.1.16",
       "process": "github:jspm/nodelibs-process@0.1.1"
     },
     "npm:postcss-modules-local-by-default@0.0.9": {
       "css-selector-tokenizer": "npm:css-selector-tokenizer@0.4.1",
-      "postcss": "npm:postcss@4.1.13"
+      "postcss": "npm:postcss@4.1.16"
     },
     "npm:postcss-modules-scope@0.0.7": {
-      "css-selector-tokenizer": "npm:css-selector-tokenizer@0.5.2",
-      "postcss": "npm:postcss@4.1.13",
+      "css-selector-tokenizer": "npm:css-selector-tokenizer@0.5.4",
+      "postcss": "npm:postcss@4.1.16",
       "process": "github:jspm/nodelibs-process@0.1.1"
     },
-    "npm:postcss@4.1.13": {
+    "npm:postcss@4.1.16": {
       "es6-promise": "npm:es6-promise@2.3.0",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "js-base64": "npm:js-base64@2.1.8",
+      "js-base64": "npm:js-base64@2.1.9",
       "path": "github:jspm/nodelibs-path@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.1",
-      "source-map": "npm:source-map@0.4.2",
+      "source-map": "npm:source-map@0.4.4",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
     },
-    "npm:source-map@0.4.2": {
-      "amdefine": "npm:amdefine@0.1.1",
-      "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "path": "github:jspm/nodelibs-path@0.1.0",
+    "npm:source-map@0.4.4": {
+      "amdefine": "npm:amdefine@1.0.0",
       "process": "github:jspm/nodelibs-process@0.1.1"
     },
     "npm:util@0.10.3": {


### PR DESCRIPTION
Hi it's me again

Can you confirm that the demo is still running for you with a fresh `jspm i` ?
Mine don't...
It ends up with a naughty

```
Uncaught SyntaxError: Unexpected token {
Potentially unhandled rejection [2] Error loading "src/main.css!npm:jspm-loader-css-modules@0.1.2" at http://localhost:3000/src/main.css
Error loading "src/main.css!npm:jspm-loader-css-modules@0.1.2" from "src/main" at http://localhost:3000/src/main.js
Error evaluating http://localhost:3000/src/main.css
Uncaught SyntaxError: Unexpected token { (WARNING: non-Error used)
```

The only change I made are below.
with 

```
$ jspm inspect
     Installed Versions

                github:jspm/nodelibs-assert 0.1.0
                github:jspm/nodelibs-buffer 0.1.0
                    github:jspm/nodelibs-fs 0.1.2
                github:jspm/nodelibs-module 0.1.0
                  github:jspm/nodelibs-path 0.1.0
               github:jspm/nodelibs-process 0.1.1
                  github:jspm/nodelibs-util 0.1.0
                github:systemjs/plugin-json 0.1.0
                               npm:amdefine 1.0.0
                                 npm:assert 1.3.0
                             npm:babel-core 5.8.20
                          npm:babel-runtime 5.8.20
                              npm:base64-js 0.0.8
                                 npm:buffer 3.3.1
                                npm:core-js 0.9.18
                npm:css-modules-loader-core 0.0.10
                 npm:css-selector-tokenizer 0.4.1 0.5.4
                                 npm:cssesc 0.1.0
                            npm:es6-promise 2.3.0
                              npm:fastparse 1.1.1
                                npm:ieee754 1.1.6
                               npm:inherits 2.0.1
                               npm:is-array 1.0.1
                              npm:js-base64 2.1.9
                        npm:jspm-loader-css 0.1.6
                npm:jspm-loader-css-modules 0.1.2
                                   npm:path 0.11.14
                        npm:path-browserify 0.0.0
                                npm:postcss 4.1.16
        npm:postcss-modules-extract-imports 0.0.5
       npm:postcss-modules-local-by-default 0.0.9
                  npm:postcss-modules-scope 0.0.7
                                npm:process 0.10.1
                             npm:source-map 0.4.4
                                   npm:util 0.10.3

```
