### PR TITLE
some changes for more appropriate config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+node_modules
 jspm_packages
 build.js
 build.js.map

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "jspm": {
     "directories": {},
     "dependencies": {
-      "css": "npm:jspm-loader-css-modules@^0.1.2",
-      "css-global": "npm:jspm-loader-css@^0.1.3",
-      "path": "npm:path@^0.11.14"
+      "css": "npm:jspm-loader-css-modules@^0.1.2"
     },
     "devDependencies": {
       "babel": "npm:babel-core@^5.1.13",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "dependencies": {
+    "jspm": "^0.15.7"
+  },
   "jspm": {
     "directories": {},
     "dependencies": {


### PR DESCRIPTION
- 67b917f I suppose developers who experiment on open source. They didn't install global jspm.
  
  Commonly they did `npm install` first. Therefore, I recommend to add dependencies on `package.json`.
- 32fcf66 Should work with only one jspm dependency
