### PR TITLE
Make it work with Jspm 0.16

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,138 +1,148 @@
 System.config({
-  "transpiler": "babel",
-  "babelOptions": {
+  defaultJSExtensions: true,
+  transpiler: "babel",
+  babelOptions: {
     "optional": [
       "runtime"
     ]
   },
-  "paths": {
-    "*": "*.js",
-    "github:*": "jspm_packages/github/*.js",
-    "npm:*": "jspm_packages/npm/*.js"
+  paths: {
+    "github:*": "jspm_packages/github/*",
+    "npm:*": "jspm_packages/npm/*"
   },
-  "trace": true
-});
+  trace: true,
 
-System.config({
-  "map": {
+  map: {
     "babel": "npm:babel-core@5.5.6",
     "babel-runtime": "npm:babel-runtime@5.5.6",
     "core-js": "npm:core-js@0.9.15",
-    "css": "npm:jspm-loader-css-modules@0.1.2",
-    "css-global": "npm:jspm-loader-css@0.1.5",
+    "css": "npm:jspm-loader-css-modules@1.0.1-beta1",
+    "css-global": "npm:jspm-loader-css@1.0.1-beta1",
     "path": "npm:path@0.11.14",
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.3.0"
     },
     "github:jspm/nodelibs-buffer@0.1.0": {
-      "buffer": "npm:buffer@3.2.2"
+      "buffer": "npm:buffer@3.5.1"
     },
     "github:jspm/nodelibs-path@0.1.0": {
       "path-browserify": "npm:path-browserify@0.0.0"
     },
-    "github:jspm/nodelibs-process@0.1.1": {
-      "process": "npm:process@0.10.1"
+    "github:jspm/nodelibs-process@0.1.2": {
+      "process": "npm:process@0.11.2"
     },
     "github:jspm/nodelibs-util@0.1.0": {
       "util": "npm:util@0.10.3"
-    },
-    "npm:amdefine@0.1.1": {
-      "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "module": "github:jspm/nodelibs-module@0.1.0",
-      "path": "github:jspm/nodelibs-path@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.1"
     },
     "npm:assert@1.3.0": {
       "util": "npm:util@0.10.3"
     },
     "npm:babel-runtime@5.5.6": {
-      "process": "github:jspm/nodelibs-process@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:buffer@3.2.2": {
+    "npm:buffer@3.5.1": {
       "base64-js": "npm:base64-js@0.0.8",
       "ieee754": "npm:ieee754@1.1.6",
       "is-array": "npm:is-array@1.0.1"
     },
     "npm:core-js@0.9.15": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "process": "github:jspm/nodelibs-process@0.1.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
     },
-    "npm:css-modules-loader-core@0.0.10": {
+    "npm:css-modules-loader-core@1.0.0": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "icss-replace-symbols": "npm:icss-replace-symbols@1.0.2",
       "path": "github:jspm/nodelibs-path@0.1.0",
-      "postcss": "npm:postcss@4.1.13",
-      "postcss-modules-extract-imports": "npm:postcss-modules-extract-imports@0.0.5",
-      "postcss-modules-local-by-default": "npm:postcss-modules-local-by-default@0.0.9",
-      "postcss-modules-scope": "npm:postcss-modules-scope@0.0.7"
+      "postcss": "npm:postcss@5.0.10",
+      "postcss-modules-extract-imports": "npm:postcss-modules-extract-imports@1.0.0",
+      "postcss-modules-local-by-default": "npm:postcss-modules-local-by-default@1.0.0",
+      "postcss-modules-scope": "npm:postcss-modules-scope@1.0.0",
+      "postcss-modules-values": "npm:postcss-modules-values@1.1.0"
     },
-    "npm:css-selector-tokenizer@0.4.1": {
+    "npm:css-selector-tokenizer@0.5.4": {
+      "cssesc": "npm:cssesc@0.1.0",
       "fastparse": "npm:fastparse@1.1.1"
     },
-    "npm:css-selector-tokenizer@0.5.2": {
-      "fastparse": "npm:fastparse@1.1.1"
-    },
-    "npm:es6-promise@2.3.0": {
-      "assert": "github:jspm/nodelibs-assert@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.1",
-      "util": "github:jspm/nodelibs-util@0.1.0"
+    "npm:debounce@1.0.0": {
+      "date-now": "npm:date-now@1.0.1"
     },
     "npm:fastparse@1.1.1": {
-      "process": "github:jspm/nodelibs-process@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:has-flag@1.0.0": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:inherits@2.0.1": {
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
-    "npm:js-base64@2.1.8": {
+    "npm:js-base64@2.1.9": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0"
     },
-    "npm:jspm-loader-css-modules@0.1.2": {
-      "jspm-loader-css": "npm:jspm-loader-css@0.1.5"
+    "npm:jspm-loader-css-modules@1.0.1-beta1": {
+      "jspm-loader-css": "npm:jspm-loader-css@1.0.1-beta1"
     },
-    "npm:jspm-loader-css@0.1.5": {
-      "css-modules-loader-core": "npm:css-modules-loader-core@0.0.10",
-      "path": "npm:path@0.11.14"
+    "npm:jspm-loader-css@1.0.1-beta1": {
+      "css-modules-loader-core": "npm:css-modules-loader-core@1.0.0",
+      "debounce": "npm:debounce@1.0.0",
+      "path": "npm:path@0.12.7",
+      "toposort": "npm:toposort@0.2.12"
     },
     "npm:path-browserify@0.0.0": {
-      "process": "github:jspm/nodelibs-process@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:path@0.11.14": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "process": "github:jspm/nodelibs-process@0.1.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
       "util": "github:jspm/nodelibs-util@0.1.0"
     },
-    "npm:postcss-modules-extract-imports@0.0.5": {
-      "postcss": "npm:postcss@4.1.13",
-      "process": "github:jspm/nodelibs-process@0.1.1"
+    "npm:path@0.12.7": {
+      "process": "npm:process@0.11.2",
+      "util": "npm:util@0.10.3"
     },
-    "npm:postcss-modules-local-by-default@0.0.9": {
-      "css-selector-tokenizer": "npm:css-selector-tokenizer@0.4.1",
-      "postcss": "npm:postcss@4.1.13"
+    "npm:postcss-modules-extract-imports@1.0.0": {
+      "postcss": "npm:postcss@5.0.10",
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:postcss-modules-scope@0.0.7": {
-      "css-selector-tokenizer": "npm:css-selector-tokenizer@0.5.2",
-      "postcss": "npm:postcss@4.1.13",
-      "process": "github:jspm/nodelibs-process@0.1.1"
+    "npm:postcss-modules-local-by-default@1.0.0": {
+      "css-selector-tokenizer": "npm:css-selector-tokenizer@0.5.4",
+      "postcss": "npm:postcss@5.0.10"
     },
-    "npm:postcss@4.1.13": {
-      "es6-promise": "npm:es6-promise@2.3.0",
+    "npm:postcss-modules-scope@1.0.0": {
+      "css-selector-tokenizer": "npm:css-selector-tokenizer@0.5.4",
+      "postcss": "npm:postcss@5.0.10",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:postcss-modules-values@1.1.0": {
+      "icss-replace-symbols": "npm:icss-replace-symbols@1.0.2",
+      "postcss": "npm:postcss@5.0.10"
+    },
+    "npm:postcss@5.0.10": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "js-base64": "npm:js-base64@2.1.8",
+      "js-base64": "npm:js-base64@2.1.9",
       "path": "github:jspm/nodelibs-path@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.1",
-      "source-map": "npm:source-map@0.4.2",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "source-map": "npm:source-map@0.5.3",
+      "supports-color": "npm:supports-color@3.1.2",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
     },
-    "npm:source-map@0.4.2": {
-      "amdefine": "npm:amdefine@0.1.1",
-      "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "path": "github:jspm/nodelibs-path@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.1"
+    "npm:process@0.11.2": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0"
+    },
+    "npm:source-map@0.5.3": {
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:supports-color@3.1.2": {
+      "has-flag": "npm:has-flag@1.0.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
+    },
+    "npm:toposort@0.2.12": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:util@0.10.3": {
       "inherits": "npm:inherits@2.0.1",
-      "process": "github:jspm/nodelibs-process@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
     }
   }
 });
-

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "jspm": {
-    "directories": {},
     "dependencies": {
-      "css": "npm:jspm-loader-css-modules@^0.1.2",
-      "css-global": "npm:jspm-loader-css@^0.1.3",
+      "css": "npm:jspm-loader-css-modules@^1.0.1-beta1",
+      "css-global": "npm:jspm-loader-css@^1.0.1-beta1",
       "path": "npm:path@^0.11.14"
     },
     "devDependencies": {


### PR DESCRIPTION
By updating
- jspm-loader-css-modules to version 1.0.1-beta1
- jspm-loader-css to version 1.0.1-beta1

Note that due to a bug in SystemJS, one has to modify the file
jspm_packages/npm/postcss@5.0.10/lib/parse.js
so that a module isn't required in a string.
In other words, line 14 has to be changed to something like this
(just removing the require statement is enough)

```
throw new Error('Option safe was removed. ' + 'Use parser: "postcss-safe-parser"');
```

Fixes #4 #6 #7
